### PR TITLE
Add z-index to prevent overlap.

### DIFF
--- a/src/themes/default/_main.scss
+++ b/src/themes/default/_main.scss
@@ -20,6 +20,7 @@
     border: 1px solid grey;
     border-top: none;
     border-radius: 2px;
+    z-index: 1;
   }
 
   button {


### PR DESCRIPTION
When two dropdowns are stacked near each other, the ul needs to fall on top of the input field of the one below it. Adding a z-index to the stacking context appears to resolve the issue.

I've verified this works by changing the css in my local use case, but have not tested against multiple unique environments.